### PR TITLE
temp: early start for storing CV data.

### DIFF
--- a/src/CvPartner/Models/DTOs.cs
+++ b/src/CvPartner/Models/DTOs.cs
@@ -2,25 +2,6 @@
 #pragma warning disable CS8618
 namespace CvPartner.Models;
 
-public class FitThumb
-{
-    public string url { get; set; }
-}
-
-public class Image
-{
-    public string? url { get; set; }
-    public Thumb thumb { get; set; }
-    public FitThumb fit_thumb { get; set; }
-    public Large large { get; set; }
-    public SmallThumb small_thumb { get; set; }
-}
-
-public class Large
-{
-    public string url { get; set; }
-}
-
 public class CVPartnerUserDTO
 {
     public string user_id { get; set; }
@@ -62,6 +43,107 @@ public class CVPartnerUserDTO
     public string default_cv_id { get; set; }
 }
 
+public class CVPartnerCvDTO
+{
+    public string _id { get; set; }
+    public List<Blog> blogs { get; set; }
+    public int born_day { get; set; }
+    public int born_month { get; set; }
+    public int born_year { get; set; }
+    public string bruker_id { get; set; }
+    public List<Certification> certifications { get; set; }
+    public DateTime created_at { get; set; }
+    public List<object> custom_tag_ids { get; set; }
+    public List<CvRole> cv_roles { get; set; }
+    public bool @default { get; set; }
+    public List<Education> educations { get; set; }
+    public object imported_date { get; set; }
+    public List<KeyQualification> key_qualifications { get; set; }
+    public object landline { get; set; }
+    public List<Language> languages { get; set; }
+    public object level { get; set; }
+    public object locked_at { get; set; }
+    public object locked_until { get; set; }
+    public object modifier_id { get; set; }
+    public NameMultilang name_multilang { get; set; }
+    public Nationality nationality { get; set; }
+    public string navn { get; set; }
+    public object order { get; set; }
+    public DateTime owner_updated_at { get; set; }
+    public DateTime owner_updated_at_significant { get; set; }
+    public PlaceOfResidence place_of_residence { get; set; }
+    public List<Position> positions { get; set; }
+    public List<CvPartnerPresentationDTO> presentations { get; set; }
+    public List<ProjectExperience> project_experiences { get; set; }
+    public List<Recommendation> recommendations { get; set; }
+    public List<Technology> technologies { get; set; }
+    public string telefon { get; set; }
+    public object tilbud_id { get; set; }
+    public Title title { get; set; }
+    public string twitter { get; set; }
+    public DateTime updated_at { get; set; }
+    public int version { get; set; }
+    public List<WorkExperience> work_experiences { get; set; }
+    public string name { get; set; }
+    public string user_id { get; set; }
+    public string company_id { get; set; }
+    public object external_unique_id { get; set; }
+    public string email { get; set; }
+    public string country_code { get; set; }
+    public string language_code { get; set; }
+    public List<string> language_codes { get; set; }
+    public object proposal { get; set; }
+    public List<object> custom_tags { get; set; }
+    public string updated_ago { get; set; }
+    public string template_document_type { get; set; }
+    public string default_word_template_id { get; set; }
+    public object default_ppt_template_id { get; set; }
+    public List<object> courses { get; set; }
+    public List<object> highlighted_roles { get; set; }
+    public Image image { get; set; }
+    public bool can_write { get; set; }
+}
+
+public class CvPartnerPresentationDTO
+{
+    public string _id { get; set; }
+    public DateTime created_at { get; set; }
+    public Description description { get; set; }
+    public bool disabled { get; set; }
+    public bool diverged_from_master { get; set; }
+    public object external_unique_id { get; set; }
+    public LongDescription long_description { get; set; }
+    public object modifier_id { get; set; }
+    public string month { get; set; }
+    public int order { get; set; }
+    public object origin_id { get; set; }
+    public DateTime? owner_updated_at { get; set; }
+    public bool recently_added { get; set; }
+    public bool starred { get; set; }
+    public DateTime updated_at { get; set; }
+    public int version { get; set; }
+    public string year { get; set; }
+}
+
+public class FitThumb
+{
+    public string url { get; set; }
+}
+
+public class Image
+{
+    public string? url { get; set; }
+    public Thumb thumb { get; set; }
+    public FitThumb fit_thumb { get; set; }
+    public Large large { get; set; }
+    public SmallThumb small_thumb { get; set; }
+}
+
+public class Large
+{
+    public string url { get; set; }
+}
+
 public class SmallThumb
 {
     public string url { get; set; }
@@ -71,3 +153,437 @@ public class Thumb
 {
     public string url { get; set; }
 }
+
+public class Blog
+{
+    public string _id { get; set; }
+    public DateTime created_at { get; set; }
+    public bool disabled { get; set; }
+    public bool diverged_from_master { get; set; }
+    public object external_unique_id { get; set; }
+    public LongDescription long_description { get; set; }
+    public object modifier_id { get; set; }
+    public object month { get; set; }
+    public Name name { get; set; }
+    public int order { get; set; }
+    public object origin_id { get; set; }
+    public DateTime? owner_updated_at { get; set; }
+    public bool recently_added { get; set; }
+    public bool starred { get; set; }
+    public DateTime updated_at { get; set; }
+    public string url { get; set; }
+    public int version { get; set; }
+    public object year { get; set; }
+}
+
+public class Category
+{
+    public string no { get; set; }
+}
+
+public class Certification
+{
+    public string _id { get; set; }
+    public DateTime created_at { get; set; }
+    public bool disabled { get; set; }
+    public bool diverged_from_master { get; set; }
+    public object external_unique_id { get; set; }
+    public LongDescription long_description { get; set; }
+    public object modifier_id { get; set; }
+    public string month { get; set; }
+    public string month_expire { get; set; }
+    public Name name { get; set; }
+    public int order { get; set; }
+    public Organiser organiser { get; set; }
+    public object origin_id { get; set; }
+    public DateTime owner_updated_at { get; set; }
+    public bool recently_added { get; set; }
+    public bool starred { get; set; }
+    public DateTime updated_at { get; set; }
+    public int version { get; set; }
+    public string year { get; set; }
+    public string year_expire { get; set; }
+    public List<object> attachments { get; set; }
+    public bool is_expired { get; set; }
+}
+
+public class Customer
+{
+    public string no { get; set; }
+    public string @int { get; set; }
+}
+
+public class CustomerAnonymized
+{
+}
+
+public class CustomerDescription
+{
+}
+
+public class CustomerValueProposition
+{
+    public string no { get; set; }
+    public string @int { get; set; }
+}
+
+public class CvRole
+{
+    public string _id { get; set; }
+    public DateTime created_at { get; set; }
+    public bool disabled { get; set; }
+    public bool diverged_from_master { get; set; }
+    public object modifier_id { get; set; }
+    public Name name { get; set; }
+    public int order { get; set; }
+    public object origin_id { get; set; }
+    public DateTime? owner_updated_at { get; set; }
+    public bool recently_added { get; set; }
+    public bool starred { get; set; }
+    public object starred_order { get; set; }
+    public DateTime updated_at { get; set; }
+    public int? version { get; set; }
+    public int years_of_experience { get; set; }
+    public int years_of_experience_offset { get; set; }
+    public List<ProjectExperience> project_experiences { get; set; }
+}
+
+public class Degree
+{
+    public string no { get; set; }
+}
+
+public class Description
+{
+    public string no { get; set; }
+    public string @int { get; set; }
+}
+
+public class Education
+{
+    public string _id { get; set; }
+    public DateTime created_at { get; set; }
+    public Degree degree { get; set; }
+    public Description description { get; set; }
+    public bool disabled { get; set; }
+    public bool diverged_from_master { get; set; }
+    public object external_unique_id { get; set; }
+    public object modifier_id { get; set; }
+    public string month_from { get; set; }
+    public string month_to { get; set; }
+    public int order { get; set; }
+    public object origin_id { get; set; }
+    public object owner_updated_at { get; set; }
+    public bool recently_added { get; set; }
+    public School school { get; set; }
+    public bool starred { get; set; }
+    public DateTime updated_at { get; set; }
+    public int version { get; set; }
+    public string year_from { get; set; }
+    public string year_to { get; set; }
+    public List<object> attachments { get; set; }
+}
+
+public class Employer
+{
+    public string no { get; set; }
+    public string @int { get; set; }
+}
+
+public class Industry
+{
+    public string no { get; set; }
+}
+
+public class KeyQualification
+{
+    public string _id { get; set; }
+    public DateTime created_at { get; set; }
+    public bool disabled { get; set; }
+    public bool diverged_from_master { get; set; }
+    public object external_unique_id { get; set; }
+    public Label label { get; set; }
+    public LongDescription long_description { get; set; }
+    public object modifier_id { get; set; }
+    public int order { get; set; }
+    public object origin_id { get; set; }
+    public object owner_updated_at { get; set; }
+    public bool recently_added { get; set; }
+    public bool starred { get; set; }
+    public TagLine tag_line { get; set; }
+    public DateTime updated_at { get; set; }
+    public int version { get; set; }
+}
+
+public class Label
+{
+    public string no { get; set; }
+    public string @int { get; set; }
+}
+
+public class Language
+{
+    public string _id { get; set; }
+    public DateTime created_at { get; set; }
+    public bool disabled { get; set; }
+    public bool diverged_from_master { get; set; }
+    public object external_unique_id { get; set; }
+    public Level level { get; set; }
+    public object modifier_id { get; set; }
+    public Name name { get; set; }
+    public int order { get; set; }
+    public object origin_id { get; set; }
+    public object owner_updated_at { get; set; }
+    public bool recently_added { get; set; }
+    public bool starred { get; set; }
+    public DateTime updated_at { get; set; }
+    public int version { get; set; }
+}
+
+public class Level
+{
+    public string no { get; set; }
+}
+
+public class LongDescription
+{
+    public string no { get; set; }
+    public string @int { get; set; }
+}
+
+public class Name
+{
+    public string no { get; set; }
+    public string @int { get; set; }
+}
+
+public class NameMultilang
+{
+}
+
+public class Nationality
+{
+    public string no { get; set; }
+}
+
+public class Organiser
+{
+    public string no { get; set; }
+}
+
+public class PlaceOfResidence
+{
+    public string no { get; set; }
+}
+
+public class Position
+{
+    public string _id { get; set; }
+    public DateTime created_at { get; set; }
+    public Description description { get; set; }
+    public bool disabled { get; set; }
+    public bool diverged_from_master { get; set; }
+    public object external_unique_id { get; set; }
+    public object modifier_id { get; set; }
+    public Name name { get; set; }
+    public int order { get; set; }
+    public object origin_id { get; set; }
+    public DateTime? owner_updated_at { get; set; }
+    public bool recently_added { get; set; }
+    public bool starred { get; set; }
+    public DateTime updated_at { get; set; }
+    public int version { get; set; }
+    public string year_from { get; set; }
+    public string year_to { get; set; }
+}
+
+public class ProjectExperience
+{
+    public string _id { get; set; }
+    public List<Role> roles { get; set; }
+    public bool diverged_from_master { get; set; }
+    public object area_amt { get; set; }
+    public object area_unit { get; set; }
+    public DateTime created_at { get; set; }
+    public Customer customer { get; set; }
+    public CustomerAnonymized customer_anonymized { get; set; }
+    public CustomerDescription customer_description { get; set; }
+    public string customer_selected { get; set; }
+    public CustomerValueProposition customer_value_proposition { get; set; }
+    public Description description { get; set; }
+    public bool disabled { get; set; }
+    public List<object> exclude_tags { get; set; }
+    public object expected_roll_off_date { get; set; }
+    public string extent_hours { get; set; }
+    public object external_unique_id { get; set; }
+    public Industry industry { get; set; }
+    public object location_country_code { get; set; }
+    public LongDescription long_description { get; set; }
+    public object modifier_id { get; set; }
+    public string month_from { get; set; }
+    public string month_to { get; set; }
+    public int order { get; set; }
+    public object origin_id { get; set; }
+    public DateTime? owner_updated_at { get; set; }
+    public string percent_allocated { get; set; }
+    public List<ProjectExperienceSkill> project_experience_skills { get; set; }
+    public string project_extent_amt { get; set; }
+    public string project_extent_currency { get; set; }
+    public string project_extent_hours { get; set; }
+    public ProjectType project_type { get; set; }
+    public bool recently_added { get; set; }
+    public object related_work_experience_id { get; set; }
+    public bool starred { get; set; }
+    public string total_extent_amt { get; set; }
+    public string total_extent_currency { get; set; }
+    public string total_extent_hours { get; set; }
+    public DateTime updated_at { get; set; }
+    public int version { get; set; }
+    public string year_from { get; set; }
+    public string year_to { get; set; }
+    public List<object> images { get; set; }
+}
+
+public class ProjectExperienceSkill
+{
+    public string _id { get; set; }
+    public int base_duration_in_years { get; set; }
+    public object modifier_id { get; set; }
+    public int offset_duration_in_years { get; set; }
+    public int order { get; set; }
+    public int proficiency { get; set; }
+    public Tags tags { get; set; }
+    public int total_duration_in_years { get; set; }
+    public int? version { get; set; }
+}
+
+public class ProjectType
+{
+}
+
+public class Recommendation
+{
+    public string _id { get; set; }
+    public DateTime created_at { get; set; }
+    public bool disabled { get; set; }
+    public bool diverged_from_master { get; set; }
+    public object external_unique_id { get; set; }
+    public LongDescription long_description { get; set; }
+    public object modifier_id { get; set; }
+    public int order { get; set; }
+    public object origin_id { get; set; }
+    public object owner_updated_at { get; set; }
+    public bool recently_added { get; set; }
+    public Recommender recommender { get; set; }
+    public bool starred { get; set; }
+    public DateTime updated_at { get; set; }
+    public int version { get; set; }
+}
+
+public class Recommender
+{
+    public string no { get; set; }
+}
+
+public class Role
+{
+    public string _id { get; set; }
+    public DateTime? created_at { get; set; }
+    public string cv_role_id { get; set; }
+    public bool disabled { get; set; }
+    public bool diverged_from_master { get; set; }
+    public LongDescription long_description { get; set; }
+    public object modifier_id { get; set; }
+    public Name name { get; set; }
+    public int order { get; set; }
+    public object origin_id { get; set; }
+    public bool recently_added { get; set; }
+    public bool starred { get; set; }
+    public Summary summary { get; set; }
+    public DateTime? updated_at { get; set; }
+    public int? version { get; set; }
+}
+
+
+public class School
+{
+    public string no { get; set; }
+}
+
+public class Summary
+{
+    public string no { get; set; }
+}
+
+public class TagLine
+{
+}
+
+public class Tags
+{
+    public string no { get; set; }
+}
+
+public class Technology
+{
+    public string _id { get; set; }
+    public Category category { get; set; }
+    public DateTime created_at { get; set; }
+    public bool disabled { get; set; }
+    public bool diverged_from_master { get; set; }
+    public List<object> exclude_tags { get; set; }
+    public object external_unique_id { get; set; }
+    public object modifier_id { get; set; }
+    public int order { get; set; }
+    public object origin_id { get; set; }
+    public DateTime? owner_updated_at { get; set; }
+    public bool recently_added { get; set; }
+    public bool starred { get; set; }
+    public List<TechnologySkill> technology_skills { get; set; }
+    public bool uncategorized { get; set; }
+    public DateTime updated_at { get; set; }
+    public int version { get; set; }
+}
+
+public class TechnologySkill
+{
+    public string _id { get; set; }
+    public int base_duration_in_years { get; set; }
+    public object modifier_id { get; set; }
+    public int offset_duration_in_years { get; set; }
+    public int order { get; set; }
+    public int proficiency { get; set; }
+    public Tags tags { get; set; }
+    public int total_duration_in_years { get; set; }
+    public int? version { get; set; }
+}
+
+public class Title
+{
+    public string no { get; set; }
+}
+
+public class WorkExperience
+{
+    public string _id { get; set; }
+    public DateTime created_at { get; set; }
+    public Description description { get; set; }
+    public bool disabled { get; set; }
+    public bool diverged_from_master { get; set; }
+    public Employer employer { get; set; }
+    public object external_unique_id { get; set; }
+    public LongDescription long_description { get; set; }
+    public object modifier_id { get; set; }
+    public string month_from { get; set; }
+    public string month_to { get; set; }
+    public int order { get; set; }
+    public object origin_id { get; set; }
+    public DateTime? owner_updated_at { get; set; }
+    public bool recently_added { get; set; }
+    public bool starred { get; set; }
+    public DateTime updated_at { get; set; }
+    public int version { get; set; }
+    public string year_from { get; set; }
+    public string year_to { get; set; }
+}
+

--- a/src/CvPartner/Repositories/CVPartnerRepository.cs
+++ b/src/CvPartner/Repositories/CVPartnerRepository.cs
@@ -23,13 +23,26 @@ public class CvPartnerRepository
     public async Task<List<CVPartnerUserDTO>> GetAllEmployees()
     {
         var apiResponse = await _cvPartnerApiClient.GetAllEmployee(_appSettings.Value.CvPartner.Token);
-        
-        if (apiResponse is {IsSuccessStatusCode: true, Content: not null })
+
+        if (apiResponse is { IsSuccessStatusCode: true, Content: not null })
         {
             return apiResponse.Content.ToList();
         }
-        
+
         _logger.LogCritical(apiResponse.Error, "Exception when calling CVPartner");
         return new List<CVPartnerUserDTO>();
+    }
+
+    public async Task<CVPartnerCvDTO> GetEmployeeCv(string userId, string cvId)
+    {
+        var apiResponse = await _cvPartnerApiClient.GetEmployeeCv(userId, cvId, _appSettings.Value.CvPartner.Token);
+
+        if (apiResponse is { IsSuccessStatusCode: true, Content: not null })
+        {
+            return apiResponse.Content;
+        }
+
+        _logger.LogCritical(apiResponse.Error, "Exception when calling CVPartner");
+        return new CVPartnerCvDTO();
     }
 }

--- a/src/CvPartner/Repositories/ICvPartnerApiClient.cs
+++ b/src/CvPartner/Repositories/ICvPartnerApiClient.cs
@@ -6,6 +6,9 @@ namespace CvPartner.Repositories;
 
 public interface ICvPartnerApiClient
 {
-    [Get("/users/search?size=200&deactivated=false")]
+    [Get("/v2/users/search?size=200&deactivated=false")]
     Task<IApiResponse<IEnumerable<CVPartnerUserDTO>>> GetAllEmployee([Authorize("Token")] string authorization);
+
+    [Get("/v3/cvs/{userId}/{cvId}")]
+    Task<IApiResponse<CVPartnerCvDTO>> GetEmployeeCv(string userId, string cvId, [Authorize("Token")] string authorization);
 }

--- a/src/CvPartner/Service/CvPartnerService.cs
+++ b/src/CvPartner/Service/CvPartnerService.cs
@@ -20,4 +20,14 @@ public class CvPartnerService
     {
         return await _cvPartnerRepository.GetAllEmployees();
     }
+
+    /**
+     * <summary>Calls CvPartnerRepository's GetAllEmployee and converts them
+     * to an employee. Adds to database.</summary>
+     */
+    public async Task<List<CvPartnerPresentationDTO>> GetCvPartnerPresentations(string userId, string cvId)
+    {
+        var employee = await _cvPartnerRepository.GetEmployeeCv(userId, cvId);
+        return employee.presentations ?? new List<CvPartnerPresentationDTO>();
+    }
 }

--- a/src/Employees/Models/PresentationEntity.cs
+++ b/src/Employees/Models/PresentationEntity.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Employees.Models;
+
+// [Index(nameof(Email), IsUnique = true)]
+public record PresentationEntity
+{
+    [Key]
+    public string? Id { get; set; }
+    public Guid EmployeeId { get; set; }
+    public EmployeeEntity Employee { get; set; } = null!;
+    public string Month { get; set; } = null!;
+    public string Year { get; set; } = null!;
+    public int Order { get; set; } = 0;
+    public string Title { get; set; } = null!;
+    public string Description { get; set; } = null!;
+    public Uri? Url { get; set; }
+
+}

--- a/src/Employees/Repositories/EmployeeContext.cs
+++ b/src/Employees/Repositories/EmployeeContext.cs
@@ -11,5 +11,6 @@ public class EmployeeContext : DbContext
     }
 
     public DbSet<EmployeeEntity> Employees { get; set; } = null!;
+    public DbSet<PresentationEntity> Presentations { get; set; } = null!;
     public DbSet<EmergencyContactEntity> EmergencyContacts { get; set; } = null!;
 }

--- a/src/Employees/Repositories/EmployeeRepository.cs
+++ b/src/Employees/Repositories/EmployeeRepository.cs
@@ -119,4 +119,26 @@ public class EmployeesRepository
 
         await _db.SaveChangesAsync();
     }
+
+    public async Task AddToDatabase(PresentationEntity presentation)
+    {
+        var updateEmergencyContact = await _db.Presentations.SingleOrDefaultAsync(e => e.Id == presentation.Id);
+
+        if (updateEmergencyContact != null)
+        {
+            updateEmergencyContact.Title = presentation.Title;
+            updateEmergencyContact.Description = presentation.Description;
+            updateEmergencyContact.EmployeeId = presentation.EmployeeId;
+            updateEmergencyContact.Month = presentation.Month;
+            updateEmergencyContact.Year = presentation.Year;
+            updateEmergencyContact.Url = presentation.Url;
+            updateEmergencyContact.Order = presentation.Order;
+        }
+        else
+        {
+            await _db.AddAsync(presentation);
+        }
+
+        await _db.SaveChangesAsync();
+    }
 }

--- a/src/Employees/Service/EmployeesService.cs
+++ b/src/Employees/Service/EmployeesService.cs
@@ -89,6 +89,11 @@ public class EmployeesService
 
         return _employeesRepository.AddToDatabase(entity);
     }
+    public Task AddOrUpdatePresentation(PresentationEntity presentation, Guid employeeId)
+    {
+        var entity = presentation with { EmployeeId = employeeId, };
+        return _employeesRepository.AddToDatabase(entity);
+    }
 
     public Boolean isValid(EmergencyContact emergencyContact)
     {

--- a/src/WebApi/appsettings.json
+++ b/src/WebApi/appsettings.json
@@ -4,7 +4,7 @@
     "UseAzureAppConfig": true,
     "BemanningConnectionString": "replace_me_on_deploy",
     "CvPartner": {
-      "Uri": "https://variant.cvpartner.com/api/v2",
+      "Uri": "https://variant.cvpartner.com/api",
       "Token": "replace_me_on_deploy"
     },
     "BlobStorage": {


### PR DESCRIPTION
Started on orchestrating storage of CV information. This isn't working code and is very much incomplete, but adding as a draft here in case its valuable insight for storing CV info for SalesGPT.

Needs to solve:

- Migrations
- Secret Endpoints (Auth, as we get data that shouldn't be publicly available)
- Foreign relationship between CV and Employee and access to the generated entity ID.
- Batching and retry. CV Partner limits number of requests to something like 20 per minute or something (verify in docs), so we'll have to batch requests in the fan-out request loop and possibly add some retry on HTTP 429
