### PR TITLE
Fix migrations being executed twice in developer mode

### DIFF
--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -151,14 +151,13 @@ app.UseCors();
 using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<EmployeeContext>();
+    var isInMemoryDatabase = db.Database.ProviderName?.StartsWith("Microsoft.EntityFrameworkCore.InMemory") ?? false;
 
-    if (app.Environment.IsDevelopment())
+    if (isInMemoryDatabase)
     {
         db.Database.EnsureCreated();
     }
-
-    var isInMemoryDatabase = db.Database.ProviderName?.StartsWith("Microsoft.EntityFrameworkCore.InMemory") ?? false;
-    if (!isInMemoryDatabase)
+    else
     {
         db.Database.Migrate();
     }


### PR DESCRIPTION
Only either EnsureCreated or Migrate should be called, not both since EnsureCreated conflicts with the migration system causing a 'table already exists' error when creating the database initially using the Azure sql container.

Opted to default to Migrate for developer mode since it's often useful there, and EnsureCreated when using the in memory database (can be changed of course 😄 ).