### PR TITLE
feat: Add architecture tests with ArchUnitNET

### DIFF
--- a/ArchitectureTests/ArchitectureTests.csproj
+++ b/ArchitectureTests/ArchitectureTests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>
+        <PackageReference Include="TngTech.ArchUnitNET.xUnit" Version="0.10.6" />
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\src\ApplicationCore\ApplicationCore.csproj" />
+      <ProjectReference Include="..\src\Infrastructure\Infrastructure.csproj" />
+      <ProjectReference Include="..\src\Shared\Shared.csproj" />
+      <ProjectReference Include="..\src\Web\Web.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/ArchitectureTests/CleanArchitectureLayerTests.cs
+++ b/ArchitectureTests/CleanArchitectureLayerTests.cs
@@ -1,0 +1,64 @@
+namespace ArchitectureTests;
+
+public class CleanArchitectureLayerTests
+{
+    // TIP: load your architecture once at the start to maximize performance of your tests
+    private static readonly Architecture Architecture = new ArchLoader().LoadAssemblies(
+        System.Reflection.Assembly.Load("ApplicationCore"),
+        System.Reflection.Assembly.Load("Infrastructure"),
+        System.Reflection.Assembly.Load("Web"),
+        System.Reflection.Assembly.Load("Shared")
+    ).Build();
+
+    private readonly IObjectProvider<IType> ApplicationCoreLayer =
+        Types().That().ResideInAssembly("ApplicationCore").As("Application Core Layer");
+
+    private readonly IObjectProvider<IType> InfrastructureLayer =
+        Types().That().ResideInNamespace("Infrastructure").As("Infrastructure Layer");
+
+    private readonly IObjectProvider<IType> WebLayer =
+        Types().That().ResideInNamespace("Web").As("Web Layer");
+    
+    private readonly IObjectProvider<IType> SharedLayer =
+        Types().That().ResideInNamespace("Shared").As("Shared Layer");
+    
+    [Fact]
+    public void ApplicationCoreLayerShouldNotAccessWebLayer()
+    {
+        IArchRule applicationCoreLayerShouldNotAccessWebLayer = Types().That().Are(ApplicationCoreLayer).Should()
+            .NotDependOnAny(WebLayer).Because("The ApplicationCore project should not depend on the Web project.");
+        applicationCoreLayerShouldNotAccessWebLayer.Check(Architecture);
+    }
+    
+    [Fact]
+    public void ApplicationCoreLayerShouldNotAccessInfrastructureLayer()
+    {
+        IArchRule applicationCoreLayerShouldNotAccessWebLayer = Types().That().Are(ApplicationCoreLayer).Should()
+            .NotDependOnAny(InfrastructureLayer).Because("The ApplicationCore project should not depend on the Web project.");
+        applicationCoreLayerShouldNotAccessWebLayer.Check(Architecture);
+    }
+    
+    [Fact]
+    public void InfrastructureLayerShouldNotAccessWebLayer()
+    {
+        IArchRule infrastructureLayerShouldNotAccessWebLayer = Types().That().Are(InfrastructureLayer).Should()
+            .NotDependOnAny(WebLayer).Because("The Infrastructure project should not depend on the Web project.");
+        infrastructureLayerShouldNotAccessWebLayer.Check(Architecture);
+    }
+    
+    [Fact]
+    public void SharedLayerShouldNotAccessAnyLayer()
+    {
+        IArchRule sharedLayerShouldNotAccessWebLayer = Types().That().Are(SharedLayer).Should()
+            .NotDependOnAny(WebLayer).Because("The Shared project should not depend on the Web project.");
+        sharedLayerShouldNotAccessWebLayer.Check(Architecture);
+        
+        IArchRule sharedLayerShouldNotAccessInfrastructureLayer = Types().That().Are(SharedLayer).Should()
+            .NotDependOnAny(InfrastructureLayer).Because("The Shared project should not depend on the Web project.");
+        sharedLayerShouldNotAccessInfrastructureLayer.Check(Architecture);
+        
+        IArchRule sharedLayerShouldNotAccessApplicationCoreLayer = Types().That().Are(SharedLayer).Should()
+            .NotDependOnAny(ApplicationCoreLayer).Because("The Shared project should not depend on the Web project.");
+        sharedLayerShouldNotAccessApplicationCoreLayer .Check(Architecture);
+    }
+}

--- a/ArchitectureTests/Usings.cs
+++ b/ArchitectureTests/Usings.cs
@@ -1,0 +1,6 @@
+global using Xunit;
+global using ArchUnitNET.Domain;
+global using ArchUnitNET.Fluent;
+global using ArchUnitNET.Loader;
+global using ArchUnitNET.xUnit;
+global using static ArchUnitNET.Fluent.ArchRuleDefinition;

--- a/Chewbacca.sln
+++ b/Chewbacca.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ComponentTests", "tests\Com
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApplicationCore", "src\ApplicationCore\ApplicationCore.csproj", "{8F20927C-B300-4C59-85B5-97108B7CCC58}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArchitectureTests", "ArchitectureTests\ArchitectureTests.csproj", "{02BC10CE-58E6-45F3-ABD2-4B96161C06FB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,6 +33,7 @@ Global
 		{ADE440BB-E9CA-4744-9B06-9675A7546DE1} = {C7322BF8-CA3C-48D3-A0AC-0D614298E2FA}
 		{704068C4-40D5-48A4-BA12-E9443BEAAE6E} = {4E8641E8-6B67-433E-BB1D-78C361EB5D1F}
 		{8F20927C-B300-4C59-85B5-97108B7CCC58} = {C7322BF8-CA3C-48D3-A0AC-0D614298E2FA}
+		{02BC10CE-58E6-45F3-ABD2-4B96161C06FB} = {4E8641E8-6B67-433E-BB1D-78C361EB5D1F}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C3F10EA1-5D15-4C94-BB62-07AAAE9ADF77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -53,5 +56,9 @@ Global
 		{8F20927C-B300-4C59-85B5-97108B7CCC58}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8F20927C-B300-4C59-85B5-97108B7CCC58}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8F20927C-B300-4C59-85B5-97108B7CCC58}.Release|Any CPU.Build.0 = Release|Any CPU
+		{02BC10CE-58E6-45F3-ABD2-4B96161C06FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{02BC10CE-58E6-45F3-ABD2-4B96161C06FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{02BC10CE-58E6-45F3-ABD2-4B96161C06FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{02BC10CE-58E6-45F3-ABD2-4B96161C06FB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This adds a test project using [ArchUnitNET](https://github.com/TNG/ArchUnitNET) to test that dependencies between projects in the solution are correct. It can also serve for more advanced tests later ensuring that Interfaces or Classes with certain names are in the correct project.