### PR TITLE
fix: cleans up employees that are added by mistake

### DIFF
--- a/src/Infrastructure/OrchestratorService.cs
+++ b/src/Infrastructure/OrchestratorService.cs
@@ -46,17 +46,6 @@ public class OrchestratorService
 
         var phoneNumberUtil = PhoneNumberUtil.GetInstance();
 
-        foreach (var bemanning in bemanningEntries.Where(employee => !IsActiveEmployee(employee)))
-        {
-            // Remove potential employees that shouldn't have been added.
-            // This should normally not happen, but might happen in cases where
-            // StartDate in bemanning wasn't set properly when orchestrating.
-            _logger.LogInformation(
-                "Deleting employee with email {BemanningEmail} from database, since they haven't started yet",
-                bemanning.Email);
-            await _employeesRepository.EnsureEmployeeIsDeleted(bemanning.Email);
-        }
-
         foreach (var bemanning in bemanningEntries.Where(IsActiveEmployee))
         {
             var cv = cvEntries.Find(cv => cv.email.ToLower().Trim() == bemanning.Email.ToLower().Trim());
@@ -104,7 +93,21 @@ public class OrchestratorService
             }
         }
 
-        var blobUrlsToBeDeleted = await _employeesRepository.EnsureEmployeesWithEndDateBeforeTodayAreDeleted();
+        // Remove employees with end date that has been passed.
+        var blobUrlsToBeDeleted = (await _employeesRepository.EnsureEmployeesWithEndDateBeforeTodayAreDeleted()).ToList();
+
+        foreach (var bemanning in bemanningEntries.Where(employee => !IsActiveEmployee(employee)))
+        {
+            // Remove potential employees that shouldn't have been added.
+            // This should normally not happen, but might happen in cases where
+            // StartDate in bemanning wasn't set properly when orchestrating. Covering an edge case
+            _logger.LogInformation(
+                "Deleting employee with email {BemanningEmail} from database, since they haven't started yet",
+                bemanning.Email);
+            blobUrlsToBeDeleted.Add(await _employeesRepository.EnsureEmployeeIsDeleted(bemanning.Email));
+        }
+
+        // Remove all potential images from both past employees and future employees
         foreach (var blobUrlToBeDeleted in blobUrlsToBeDeleted)
         {
             _logger.LogInformation("Deleting blob with url {BlobUrlToBeDeleted}", blobUrlToBeDeleted);

--- a/src/Infrastructure/OrchestratorService.cs
+++ b/src/Infrastructure/OrchestratorService.cs
@@ -46,6 +46,17 @@ public class OrchestratorService
 
         var phoneNumberUtil = PhoneNumberUtil.GetInstance();
 
+        foreach (var bemanning in bemanningEntries.Where(employee => !IsActiveEmployee(employee)))
+        {
+            // Remove potential employees that shouldn't have been added.
+            // This should normally not happen, but might happen in cases where
+            // StartDate in bemanning wasn't set properly when orchestrating.
+            _logger.LogInformation(
+                "Deleting employee with email {BemanningEmail} from database, since they haven't started yet",
+                bemanning.Email);
+            await _employeesRepository.EnsureEmployeeIsDeleted(bemanning.Email);
+        }
+
         foreach (var bemanning in bemanningEntries.Where(IsActiveEmployee))
         {
             var cv = cvEntries.Find(cv => cv.email.ToLower().Trim() == bemanning.Email.ToLower().Trim());
@@ -201,10 +212,10 @@ public class OrchestratorService
             MonthFrom = dto.month_from,
             YearFrom = dto.year_from,
             MonthTo = dto.month_to,
-            YearTo = dto.year_to, 
+            YearTo = dto.year_to,
             Title = dto.description.no ?? "",
             LastSynced = DateTime.Now
         });
     }
-    
+
 }

--- a/src/Infrastructure/OrchestratorService.cs
+++ b/src/Infrastructure/OrchestratorService.cs
@@ -96,7 +96,7 @@ public class OrchestratorService
         // Remove employees with end date that has been passed.
         var blobUrlsToBeDeleted = (await _employeesRepository.EnsureEmployeesWithEndDateBeforeTodayAreDeleted()).ToList();
 
-        foreach (var bemanning in bemanningEntries.Where(employee => !IsActiveEmployee(employee)))
+        foreach (var bemanning in bemanningEntries.Where(IsFutureEmployee))
         {
             // Remove potential employees that shouldn't have been added.
             // This should normally not happen, but might happen in cases where
@@ -125,6 +125,10 @@ public class OrchestratorService
         return DateTime.Now >= bemanning.StartDate && (bemanning.EndDate == null || DateTime.Now <= bemanning.EndDate);
     }
 
+    private static bool IsFutureEmployee(BemanningEmployee bemanning)
+    {
+        return bemanning.StartDate > DateTime.Now;
+    }
 
     // public async Task FetchMapAndSaveCvData()
     // {


### PR DESCRIPTION
In cases where bemanning isn't correctly used, the start date defaults to 2018 causing some employees to be added where they shouldn't be. These are never updated as we update only employees with a start date.

We might update everyone, but that also means we add every employee we don't have to add. This simply removes them when rerunning orchestration.

Risk here is that we also remove potentially added metadata (address, contact etc) but I guess they shouldn't have existed in the first place so it is OK.