### PR TITLE
fix: Use variant developers group as SA AAD user for SQL Server

### DIFF
--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -7,7 +7,6 @@ param location string = resourceGroup().location
 @description('The web site hosting plan')
 param sku string = 'B1'
 
-
 @description('Specifies sql admin login')
 @secure()
 param sqlAdministratorLogin string = newGuid()
@@ -85,9 +84,12 @@ module sql 'modules/sql.bicep' = {
     location: location
     sqlAdministratorLogin: sqlAdministratorLogin
     sqlAdministratorPassword: sqlAdministratorPassword
-    adminIdentitySid: web.identity.principalId
+    variantDevelopersRoleObjectId: variantDevelopersRoleObjectId
   }
 }
+  
+// TODO: Find a way to automatically create the SQL user for the webapp in the SQL server.
+// For now you have to run sql-webapp-access.sql in the database with the principalId (objectId) and name output from Bicep
 
 resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
   name: applicationInsightsName
@@ -133,3 +135,5 @@ resource webAppSettings 'Microsoft.Web/sites/config@2022-03-01' = {
 }
 
 output siteUrl string = 'https://${web.properties.defaultHostName}/'
+output webappPrincipalName string = web.name
+output webAppPrincipalId string = web.identity.principalId

--- a/infrastructure/modules/sql.bicep
+++ b/infrastructure/modules/sql.bicep
@@ -10,7 +10,7 @@ param sqlAdministratorLogin string
 @secure()
 param sqlAdministratorPassword string
 
-param adminIdentitySid string
+param variantDevelopersRoleObjectId string
 
 @description('Specifies database name')
 param sqlDatabaseName string
@@ -24,8 +24,8 @@ resource sqlserver 'Microsoft.Sql/servers@2020-11-01-preview' = {
     version: '12.0'
     administrators: {
       administratorType: 'ActiveDirectory'
-      login: 'webappAppLogin'
-      sid: adminIdentitySid
+      login: 'developers'
+      sid: variantDevelopersRoleObjectId
       tenantId: subscription().tenantId
       azureADOnlyAuthentication: true
     }

--- a/infrastructure/sql-webapp-access.sql
+++ b/infrastructure/sql-webapp-access.sql
@@ -1,0 +1,11 @@
+-- Replace the username and objectId with the output from main.bicep
+CREATE USER [chewie-webapp-ld2ijhpvmb34c] FROM EXTERNAL PROVIDER WITH OBJECT_ID='e37b130a-f343-49a3-a4e1-7710eef45e1f'
+ALTER ROLE db_accessadmin
+	ADD MEMBER [chewie-webapp-ld2ijhpvmb34c];  
+GO
+ALTER ROLE db_datareader
+	ADD MEMBER [chewie-webapp-ld2ijhpvmb34c];  
+GO
+ALTER ROLE db_datawriter
+	ADD MEMBER [chewie-webapp-ld2ijhpvmb34c];  
+GO


### PR DESCRIPTION
This introduces a manual step for now as there is no golden path from Microsoft on how to do this programtically, but the change enables every developer in Variant to do proper debugging and testing in the Azure environment