### PR TITLE
Optional `country` query param for `/Employees/{alias}`

### DIFF
--- a/src/ApplicationCore/Interfaces/IEmployeesRepository.cs
+++ b/src/ApplicationCore/Interfaces/IEmployeesRepository.cs
@@ -6,7 +6,7 @@ public interface IEmployeesRepository
 {
     Task<List<Employee>> GetAllEmployees();
     Task<List<Employee>> GetEmployeesByCountry(string country);
-    Task<Employee?> GetEmployeeAsync(string alias, string country);
+    Task<Employee?> GetEmployeeAsync(string alias, string? country = null);
     Task AddOrUpdateEmployeeInformation(Employee employee);
 
     /// <summary>

--- a/src/ApplicationCore/Services/EmployeesService.cs
+++ b/src/ApplicationCore/Services/EmployeesService.cs
@@ -40,7 +40,7 @@ public class EmployeesService
             .Where(IsEmployeeActive);
     }
 
-    public async Task<Employee?> GetByAliasAndCountry(string alias, string country)
+    public async Task<Employee?> GetByAliasAndCountry(string alias, string? country = null)
     {
         return await _employeesRepository.GetEmployeeAsync(alias, country);
     }

--- a/src/Infrastructure/Repositories/EmployeeRepository.cs
+++ b/src/Infrastructure/Repositories/EmployeeRepository.cs
@@ -70,14 +70,18 @@ public class EmployeesRepository : IEmployeesRepository
     }
 
 
-    public async Task<Employee?> GetEmployeeAsync(string alias, string country)
+    public async Task<Employee?> GetEmployeeAsync(string alias, string? country = null)
     {
-        var employee = await _db.Employees
+        var employeeQuery = _db.Employees
             .Include(employee => employee.AllergiesAndDietaryPreferences)
             .Include(employee => employee.EmergencyContact)
-            .Where(emp => emp.Email.StartsWith($"{alias}@"))
-            .Where(emp => emp.CountryCode == country)
-            .SingleOrDefaultAsync();
+            .Where(emp => emp.Email.StartsWith($"{alias}@"));
+        if (country != null)
+        {
+            employeeQuery = employeeQuery.Where(emp => emp.CountryCode == country);
+        }
+
+        var employee = await employeeQuery.SingleOrDefaultAsync();
         return employee?.ToEmployee();
     }
 

--- a/src/Web/Controllers/EmployeesController.cs
+++ b/src/Web/Controllers/EmployeesController.cs
@@ -42,7 +42,7 @@ public class EmployeesController : ControllerBase
     [HttpGet("{alias}")]
     [OutputCache(Duration = 60)]
     [AllowAnonymous]
-    public async Task<ActionResult<EmployeeJson>> GetByAlias(string alias, [FromQuery] string country)
+    public async Task<ActionResult<EmployeeJson>> GetByAlias(string alias, [FromQuery] string? country = null)
     {
         var employee = await _employeeService.GetByAliasAndCountry(alias, country);
 


### PR DESCRIPTION
Closes #132 

Makes the `country` query param optional for `/Employees/{alias}`, similar to the `/Employees` endpoint.

### with query param
<img width="684" alt="image" src="https://github.com/user-attachments/assets/aaa56ad7-2704-4caf-adec-f12982c1d4f9">

### without query param
<img width="674" alt="image" src="https://github.com/user-attachments/assets/edafa420-2efe-42d5-827b-228d15f33a01">

### with non-matching query param
<img width="646" alt="image" src="https://github.com/user-attachments/assets/17a070ca-3197-437f-8d70-811016d68a25">
